### PR TITLE
fix(devops/Dockerfile): fixed docker build

### DIFF
--- a/challenge-devops/Dockerfile
+++ b/challenge-devops/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.1-slim
+FROM ruby:2.6.3-slim
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs libsqlite3-dev \
     && apt-get clean autoclean \
     && apt-get autoremove -y


### PR DESCRIPTION
# Summary

- I thought it was not relevant to the exam, so I created a PR.
- ruby version upgrade 2.5.1 →2.6.3

# Resolved Error

```
challenge-devops $ docker image build . -t devops:latest
[+] Building 1.7s (11/12)                                                                    
 => [internal] load build definition from Dockerfile                                    0.0s
 => => transferring dockerfile: 359B                                                    0.0s
 => [internal] load .dockerignore                                                       0.0s
 => => transferring context: 2B                                                         0.0s
 => [internal] load metadata for docker.io/library/ruby:2.5.1-slim                      1.1s
 => [auth] library/ruby:pull token for registry-1.docker.io                             0.0s
 => [1/7] FROM docker.io/library/ruby:2.5.1-slim@sha256:5a88bb901da277f0b4fa73b57549b1  0.0s
 => [internal] load build context                                                       0.0s
 => => transferring context: 198.27kB                                                   0.0s
 => CACHED [2/7] RUN apt-get update -qq && apt-get install -y build-essential libpq-de  0.0s
 => CACHED [3/7] RUN mkdir /app                                                         0.0s
 => CACHED [4/7] WORKDIR /app                                                           0.0s
 => CACHED [5/7] COPY Gemfile Gemfile.lock /app/                                        0.0s
 => ERROR [6/7] RUN bundle install                                                      0.5s
------
 > [6/7] RUN bundle install:
#10 0.459 Warning: the running version of Bundler (1.16.6) is older than the version that created the lockfile (1.17.2). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
#10 0.467 Your Ruby version is 2.5.1, but your Gemfile specified 2.6.3
------
executor failed running [/bin/sh -c bundle install]: exit code: 18
```